### PR TITLE
Make use of data.strz

### DIFF
--- a/applications/foxpaint/main.asm
+++ b/applications/foxpaint/main.asm
@@ -293,13 +293,13 @@ drag_or_close_tools_window:
     pop r0
     ret
 
-canvas_window_title: data.str "FoxPaint canvas" data.8 0
+canvas_window_title: data.strz "FoxPaint canvas"
 canvas_window_struct: data.fill 0, 36
 
-tools_window_title: data.str "FoxPaint tools" data.8 0
+tools_window_title: data.strz "FoxPaint tools"
 tools_window_struct: data.fill 0, 36
 
-color_section_text: data.str "Color " data.8 0
+color_section_text: data.strz "Color "
 color_button_black_widget:
     data.32 color_button_white_widget ; next_ptr
     data.32 0                         ; id
@@ -355,35 +355,35 @@ color_button_blue_widget:
     data.16 0                         ; reserved
     data.16 48                        ; x_pos
     data.16 80                        ; y_pos
-color_button_text: data.str "  " data.8 0
+color_button_text: data.strz "  "
 
 menu_items_root:
     data.8 2                                                      ; number of menus
     data.32 menu_items_canvas_list data.32 menu_items_canvas_name ; pointer to menu list, pointer to menu name
     data.32 menu_items_brush_list data.32 menu_items_brush_name   ; pointer to menu list, pointer to menu name
 menu_items_canvas_name:
-    data.8 6 data.str "Canvas" data.8 0x00 ; text length, text, null-terminator
+    data.8 6 data.strz "Canvas" ; text length, text, null-terminator
 menu_items_brush_name:
     data.8 5 data.str "Brush"  data.8 0x00 ; text length, text, null-terminator
 menu_items_canvas_list:
     data.8 2                                        ; number of items
     data.8 16                                       ; menu width (usually longest item + 2)
-    data.8 14 data.str "Clear to Black" data.8 0x00 ; text length, text, null-terminator
-    data.8 14 data.str "Clear to White" data.8 0x00 ; text length, text, null-terminator
+    data.8 14 data.strz "Clear to Black" ; text length, text, null-terminator
+    data.8 14 data.strz "Clear to White" ; text length, text, null-terminator
 menu_items_brush_list:
     data.8 4                              ; number of items
     data.8 7                              ; menu width (usually longest item + 2)
     data.8 3 data.str "2x2"   data.8 0x00 ; text length, text, null-terminator
     data.8 3 data.str "4x4"   data.8 0x00 ; text length, text, null-terminator
     data.8 3 data.str "8x8"   data.8 0x00 ; text length, text, null-terminator
-    data.8 5 data.str "16x16" data.8 0x00 ; text length, text, null-terminator
+    data.8 5 data.strz "16x16" ; text length, text, null-terminator
 menu_items_color_list:
     data.8 5                              ; number of items
     data.8 7                              ; menu width (usually longest item + 2)
-    data.8 5 data.str "Black" data.8 0x00 ; text length, text, null-terminator
-    data.8 5 data.str "White" data.8 0x00 ; text length, text, null-terminator
+    data.8 5 data.strz "Black" ; text length, text, null-terminator
+    data.8 5 data.strz "White" ; text length, text, null-terminator
     data.8 3 data.str "Red"   data.8 0x00 ; text length, text, null-terminator
-    data.8 5 data.str "Green" data.8 0x00 ; text length, text, null-terminator
+    data.8 5 data.strz "Green" ; text length, text, null-terminator
     data.8 4 data.str "Blue"  data.8 0x00 ; text length, text, null-terminator
 
 is_drawing: data.8 0

--- a/applications/launcher/main.asm
+++ b/applications/launcher/main.asm
@@ -81,10 +81,10 @@ close_window:
     call destroy_window
     call end_current_task
 
-window_title: data.str "Launcher" data.8 0
+window_title: data.strz "Launcher"
 window_struct: data.fill 0, 36
 
-terminal_button_fxf: data.str "terminalfxf" data.8 0
+terminal_button_fxf: data.strz "terminalfxf"
 terminal_button_widget:
     data.32 0                  ; next_ptr
     data.32 0                  ; id
@@ -96,7 +96,7 @@ terminal_button_widget:
     data.16 0                  ; reserved
     data.16 72                 ; x_pos
     data.16 0                  ; y_pos
-button_text: data.str "  " data.8 0
+button_text: data.strz "  "
 
 icons:
     #include "icons.inc"

--- a/applications/sh/commands/clear.asm
+++ b/applications/sh/commands/clear.asm
@@ -3,7 +3,7 @@
 const FILL_TERM: 0xF0
 const MOVE_CURSOR: 0xF1
 
-shell_clear_command_string: data.str "clear" data.8 0
+shell_clear_command_string: data.strz "clear"
 
 shell_clear_command:
     movz.8 r0, FILL_TERM

--- a/applications/sh/commands/dir.asm
+++ b/applications/sh/commands/dir.asm
@@ -1,6 +1,6 @@
 ; dir command
 
-shell_dir_command_string: data.str "dir" data.8 0
+shell_dir_command_string: data.strz "dir"
 
 shell_dir_command:
     mov r0, shell_dir_command_list_buffer

--- a/applications/sh/commands/disk.asm
+++ b/applications/sh/commands/disk.asm
@@ -1,6 +1,6 @@
 ; disk command
 
-shell_disk_command_string: data.str "disk" data.8 0
+shell_disk_command_string: data.strz "disk"
 
 shell_disk_command:
     call shell_parse_arguments

--- a/applications/sh/commands/diskrm.asm
+++ b/applications/sh/commands/diskrm.asm
@@ -1,6 +1,6 @@
 ; eject command
 
-shell_diskrm_command_string: data.str "diskrm" data.8 0
+shell_diskrm_command_string: data.strz "diskrm"
 
 shell_diskrm_command:
     call shell_parse_arguments

--- a/applications/sh/commands/exit.asm
+++ b/applications/sh/commands/exit.asm
@@ -1,6 +1,6 @@
 ; exit command
 
-shell_exit_command_string: data.str "exit" data.8 0
+shell_exit_command_string: data.strz "exit"
 
 shell_exit_command:
     call end_current_task

--- a/applications/sh/commands/help.asm
+++ b/applications/sh/commands/help.asm
@@ -1,6 +1,6 @@
 ; help command
 
-shell_help_command_string: data.str "help" data.8 0
+shell_help_command_string: data.strz "help"
 
 shell_help_command:
     mov r0, shell_help_text

--- a/applications/sh/commands/shutdown.asm
+++ b/applications/sh/commands/shutdown.asm
@@ -1,6 +1,6 @@
 ; shutdown command
 
-shell_shutdown_command_string: data.str "shutdown" data.8 0
+shell_shutdown_command_string: data.strz "shutdown"
 
 shell_shutdown_command:
     call poweroff

--- a/applications/sh/commands/type.asm
+++ b/applications/sh/commands/type.asm
@@ -1,6 +1,6 @@
 ; type command
 
-shell_type_command_string: data.str "type" data.8 0
+shell_type_command_string: data.strz "type"
 
 ; FIXME: check string length before blindly copying
 shell_type_command:
@@ -87,4 +87,4 @@ shell_type_command_file: data.fill 0, 12
 shell_type_command_file_empty: data.str "           "
 shell_type_command_file_struct: data.32 0 data.32 0
 shell_type_command_file_character_buffer: data.8 0
-shell_type_command_file_not_found_string: data.str "file not found: " data.8 0
+shell_type_command_file_not_found_string: data.strz "file not found: "

--- a/applications/terminal/main.asm
+++ b/applications/terminal/main.asm
@@ -98,7 +98,7 @@ close_window:
     call end_current_task
     jmp event_loop_end
 
-window_title: data.str "Terminal" data.8 0
+window_title: data.strz "Terminal"
 window_struct: data.fill 0, 36
 
 shell_task_id: data.8 0

--- a/applications/terminal/task.asm
+++ b/applications/terminal/task.asm
@@ -64,6 +64,6 @@ sh_fxf_missing:
 
 sh_fxf_name: data.str "sh      fxf"
 sh_fxf_struct: data.fill 0, 8
-sh_fxf_missing_str: data.str "sh could not be launched!" data.8 0
+sh_fxf_missing_str: data.strz "sh could not be launched!"
 sh_fxf_binary_ptr: data.32 0
 sh_fxf_stack_ptr: data.32 0

--- a/bootloader/main.asm
+++ b/bootloader/main.asm
@@ -31,8 +31,8 @@ error:
     call [0xF0042004] ; draw_str_to_background
     rjmp 0
 
-kernel_file_name: data.str "kernel  fxf" data.8 0
+kernel_file_name: data.strz "kernel  fxf"
 kernel_file_struct: data.32 0 data.32 0
-error_str: data.str "failed to open kernel.fxf" data.8 0
+error_str: data.strz "failed to open kernel.fxf"
 
     #include "reloc.asm"

--- a/kernel/fxf/fxf.asm
+++ b/kernel/fxf/fxf.asm
@@ -18,7 +18,7 @@ parse_fxf_binary:
 
     ret
 
-fxf_magic: data.str "FXF" data.8 0
+fxf_magic: data.strz "FXF"
 
     #include "fxf/reloc.asm"
 

--- a/kernel/main.asm
+++ b/kernel/main.asm
@@ -338,12 +338,12 @@ get_os_version:
     #include "window/window.asm"
     #include "vfs.asm"
 
-bottom_bar_str_0: data.str "FOX" data.8 0
-bottom_bar_str_1: data.str "32" data.8 0
-bottom_bar_str_2: data.str " OS version %u.%u.%u " data.8 0
-startup_error_str: data.str "fox32 - OS version %u.%u.%u - startup.cfg is invalid!" data.8 0
-memory_error_str: data.str "fox32 - OS version %u.%u.%u - not enough memory to perform operation!" data.8 0
-kernelception_error_str: data.str "Error: kernelception?" data.8 0
+bottom_bar_str_0: data.strz "FOX"
+bottom_bar_str_1: data.strz "32"
+bottom_bar_str_2: data.strz " OS version %u.%u.%u "
+startup_error_str: data.strz "fox32 - OS version %u.%u.%u - startup.cfg is invalid!"
+memory_error_str: data.strz "fox32 - OS version %u.%u.%u - not enough memory to perform operation!"
+kernelception_error_str: data.strz "Error: kernelception?"
 bottom_bar_patterns:
     ; 1x16 tile
     data.32 0xFF674764

--- a/kernel/window/messagebox.asm
+++ b/kernel/window/messagebox.asm
@@ -99,7 +99,7 @@ messagebox_ok_clicked:
     pop r0
     ret
 
-messagebox_window_title: data.str "Messagebox" data.8 0
+messagebox_window_title: data.strz "Messagebox"
 messagebox_window_struct: data.fill 0, 36
 messagebox_ok_button_widget:
     data.32 0                        ; next_ptr
@@ -112,5 +112,5 @@ messagebox_ok_button_widget:
     data.16 0                        ; reserved
     data.16 8                        ; x_pos
     data.16 64                       ; y_pos
-messagebox_ok_button_str: data.str "OK" data.8 0
+messagebox_ok_button_str: data.strz "OK"
 messagebox_old_active_window_offset: data.8 0


### PR DESCRIPTION
The filesystem image is the same before and after this commit:

$ sha256sum fox32os-orig.img fox32os.img
abc77bd6310b8eb6bcde0a8a442ca8bab071307a6cf5155ea606578435f77d27  fox32os-orig.img abc77bd6310b8eb6bcde0a8a442ca8bab071307a6cf5155ea606578435f77d27  fox32os.img


The conversion was performed with a few sed commands:

find -name '*.asm' | xargs sed -i -e 's/data.str \("[^"]*"\) data.8 0$/data.strz \1/g' find -name '*.asm' | xargs sed -i -e 's/data.str \("[^"]*"\) data.8 0 /data.strz \1 /g' find -name '*.asm' | xargs sed -i -e 's/data.str \("[^"]*"\) data.8 0x00 /data.strz \1 /g'