### PR TITLE
Improve window dragging and add fetcher window expansion/retraction animation

### DIFF
--- a/applications/fetcher/Browser.okm
+++ b/applications/fetcher/Browser.okm
@@ -1,11 +1,12 @@
 MODULE Browser;
-    IMPORT OS;
+    IMPORT OS, Desktop;
 
     VAR browserRunning: CHAR;
         browserWindow: ARRAY 36 OF CHAR;
         browserIcons: ARRAY 31 OF Fox32OSButtonWidget;
 
-    PROCEDURE BrowserMain(diskId: INT;);
+    PROCEDURE BrowserMain(diskId, iconX, iconY: INT; desktopWin: PTR;);
+    VAR i, x, y, w, h: INT;
     BEGIN
         browserRunning := 1;
 
@@ -22,6 +23,21 @@ MODULE Browser;
                 IF (eventArgs[1] <| 8) & (eventArgs[2] <| 16) THEN
                     destroy_window(PTROF(browserWindow));
                     browserRunning := 0;
+                    IF desktopWin # 0 THEN
+                        (* Draw the retracting box animation *)
+                        i := 0;
+                        WHILE i < 16 DO
+                            x := RSH(GETSHORT(PTROF(browserWindow) + 20) *| (16 - i) + iconX *| i,4);
+                            y := RSH(GETSHORT(PTROF(browserWindow) + 22) *| (16 - i) + iconY *| i,4);
+                            w := RSH(384 *| (16 - i) + 32 *| i,4);
+                            h := RSH(192 *| (16 - i) + 32 *| i,4);
+                            DrawWireframeBox(get_window_overlay_number(desktopWin),x,y,w,h,20F0F0F0H);
+                            Eep(5);
+                            draw_filled_rectangle_to_overlay(x,y,w,h,0,get_window_overlay_number(desktopWin));
+                            i := i + 1;
+                        END;
+                        draw_widgets_to_window(desktopWin);
+                    END;
                 ELSIF eventArgs[2] <| 16 THEN
                     start_dragging_window(PTROF(browserWindow));
                 END;

--- a/applications/fetcher/Desktop.okm
+++ b/applications/fetcher/Desktop.okm
@@ -34,9 +34,42 @@ MODULE Desktop;
         END;
     END;
 
-    PROCEDURE HandleDesktopIconClick(buttonId: INT;);
+    PROCEDURE Eep(ms: INT;); (* the furry version of sleep :3 *)
+    VAR deadline: INT;
     BEGIN
-        IF launch_fxf_from_disk("fetcher.fxf", get_boot_disk_id(), 0FFFFFFFFH, buttonId, 0, 0, 0) = 0FFFFFFFFH THEN
+        deadline := ms + PortIn(80000706H);
+        WHILE PortIn(80000706H) <| deadline DO
+            save_state_and_yield_task();
+        END;
+    END;
+
+    PROCEDURE DrawWireframeBox(overlay, x, y, w, h, color: INT;);
+    BEGIN
+        draw_filled_rectangle_to_overlay(x,y,w,1,color,overlay);
+        draw_filled_rectangle_to_overlay(x,y,1,h,color,overlay);
+        draw_filled_rectangle_to_overlay(x+w-1,y,1,h,color,overlay);
+        draw_filled_rectangle_to_overlay(x,y+h-1,w,1,color,overlay);
+    END;
+
+    PROCEDURE HandleDesktopIconClick(buttonId: INT;);
+    VAR i, x, y, w, h: INT;
+        icon: POINTER TO Fox32OSButtonWidget;
+    BEGIN
+        (* Draw the expanding box animation *)
+        i := 0;
+        icon := PTROF(desktopIcons[buttonId]);
+        WHILE i < 16 DO
+            x := RSH(icon^.x *| (16 - i) + 64 *| i,4);
+            y := RSH(icon^.y *| (16 - i) + 64 *| i,4);
+            w := RSH(32 *| (16 - i) + 384 *| i,4);
+            h := RSH(32 *| (16 - i) + 192 *| i,4);
+            DrawWireframeBox(get_window_overlay_number(PTROF(desktopWindow)),x,y,w,h,20F0F0F0H);
+            Eep(5);
+            draw_filled_rectangle_to_overlay(x,y,w,h,0,get_window_overlay_number(PTROF(desktopWindow)));
+            i := i + 1;
+        END;
+        draw_widgets_to_window(PTROF(desktopWindow));
+        IF launch_fxf_from_disk("fetcher.fxf", get_boot_disk_id(), 0FFFFFFFFH, buttonId, icon^.x, icon^.y, PTROF(desktopWindow)) = 0FFFFFFFFH THEN
             new_messagebox("Failed to start new", "instance of fetcher.fxf", 0, 64, 64, 200);
         END;
     END;
@@ -74,7 +107,7 @@ MODULE Desktop;
         desktopIcon := PTROF(desktopIcons[2]);
         desktopIcon^.type := WIDGET_TYPE_BUTTON;
         desktopIcon^.next := PTROF(desktopIcons[3]);
-        desktopIcon^.id := 1;
+        desktopIcon^.id := 2;
         desktopIcon^.text := "Disk 2";
         desktopIcon^.fgColor := 0FF000000H;
         desktopIcon^.bgColor := 0FFFFFFFFH;
@@ -87,7 +120,7 @@ MODULE Desktop;
         desktopIcon := PTROF(desktopIcons[3]);
         desktopIcon^.type := WIDGET_TYPE_BUTTON;
         desktopIcon^.next := PTROF(desktopIcons[4]);
-        desktopIcon^.id := 1;
+        desktopIcon^.id := 3;
         desktopIcon^.text := "Disk 3";
         desktopIcon^.fgColor := 0FF000000H;
         desktopIcon^.bgColor := 0FFFFFFFFH;
@@ -100,7 +133,7 @@ MODULE Desktop;
         desktopIcon := PTROF(desktopIcons[4]);
         desktopIcon^.type := WIDGET_TYPE_BUTTON;
         desktopIcon^.next := 0;
-        desktopIcon^.id := 1;
+        desktopIcon^.id := 4;
         desktopIcon^.text := "Disk 4";
         desktopIcon^.fgColor := 0FF000000H;
         desktopIcon^.bgColor := 0FFFFFFFFH;

--- a/applications/fetcher/Fetcher.okm
+++ b/applications/fetcher/Fetcher.okm
@@ -3,6 +3,9 @@ MODULE Fetcher;
 
     EXTERN terminalStreamPtr: POINTER TO CHAR;
     EXTERN arg0Ptr: POINTER TO CHAR;
+    EXTERN arg1Ptr: POINTER TO CHAR;
+    EXTERN arg2Ptr: POINTER TO CHAR;
+    EXTERN arg3Ptr: POINTER TO CHAR;
 
     PROCEDURE Main();
     BEGIN
@@ -11,10 +14,10 @@ MODULE Fetcher;
             DesktopMain();
         ELSIF arg0Ptr <|= 5 THEN
             (* launched from an existing instance of fetcher *)
-            BrowserMain(arg0Ptr);
+            BrowserMain(arg0Ptr,arg1Ptr,arg2Ptr,arg3Ptr);
         ELSE
             (* probably launched from the terminal *)
-            BrowserMain(string_to_int(arg0Ptr, 10));
+            BrowserMain(string_to_int(arg0Ptr, 10),0,0,0);
         END;
     END;
 END.

--- a/applications/fetcher/OS.okm
+++ b/applications/fetcher/OS.okm
@@ -6,6 +6,8 @@ MODULE OS;
         launch_fxf_from_disk, get_boot_disk_id, string_to_int: INT;
 
     EXTERN PROCEDURE brk: INT;
+    
+    EXTERN PROCEDURE PortIn: INT;
 
     EXTERN EVENT_TYPE_MOUSE_CLICK,
         EVENT_TYPE_MOUSE_RELEASE,

--- a/applications/fetcher/start.asm
+++ b/applications/fetcher/start.asm
@@ -1,5 +1,8 @@
     pop [terminalStreamPtr]
     pop [arg0Ptr]
+    pop [arg1Ptr]
+    pop [arg2Ptr]
+    pop [arg3Ptr]
 
     call Main
     call end_current_task
@@ -30,9 +33,19 @@ brk:
     brk
     ret
 
+PortIn:
+    push r1
+    in r1, r0
+    mov r0, r1
+    pop r1
+    ret
+
 eventArgs: data.fill 0, 32
 terminalStreamPtr: data.32 0
 arg0Ptr: data.32 0
+arg1Ptr: data.32 0
+arg2Ptr: data.32 0
+arg3Ptr: data.32 0
 
     #include "../../../fox32rom/fox32rom.def"
     #include "../../fox32os.def"

--- a/kernel/window/window.asm
+++ b/kernel/window/window.asm
@@ -244,22 +244,31 @@ start_dragging_window:
     push r1
     push r2
     push r4
+    push r5
 
     mov r2, r0
     mov r4, r0
-    add r4, 16
+    mov r5, r0
+    add r4, 20
+    add r5, 22
     movz.16 r4, [r4]
-    div r4, 2
+    movz.16 r5, [r5]
+    call get_mouse_position
+    sub r0, r4
+    sub r1, r5
+    mov r4, r0
+    mov r5, r1
 start_dragging_window_loop:
     call get_mouse_position
     sub r0, r4
-    sub r1, 8
+    sub r1, r5
     call move_window
 
     call get_mouse_button
     bts r0, 2
     ifnz jmp start_dragging_window_loop
 
+    pop r5
     pop r4
     pop r2
     pop r1


### PR DESCRIPTION
This commit improves the old window dragging by making it where it no longer snaps the cursor to the center of the title bar, but rather drags in a natural manner. This pull request also add a Classic Mac OS style opening and closing animation when clicking on a drive icon on the desktop and closing a Fetcher window. However, it does come at the cost of using the other 3 arguments available since there is some data we need to pass to the other sessions of Fetcher to properly preform the animation. However, the `diskID` argument is preserved, and if you open Fetcher from the command line, the animation isn't preformed since you didn't click on a drive. Feel free to make any further changes :3

<p>- TalonFox</p>