### PR TITLE
Swap top window when destroying a window

### DIFF
--- a/kernel/window/window.asm
+++ b/kernel/window/window.asm
@@ -175,30 +175,9 @@ new_window:
 destroy_window:
     push r0
     push r1
+    push r2
 
-    mov r1, r0
-
-    ; free framebuffer memory
-    mov r0, [r1]
-    call free_memory
-
-    ; free event queue memory
-    add r1, 8
-    mov r0, [r1]
-    call free_memory
-
-    ; disable the window's overlay
-    add r1, 16
-    movz.8 r0, [r1]
-    call disable_overlay
-
-    ; remove the window from the window list
-    sub r1, 24
-    mov r0, r1
-    call search_for_window_list_entry
-    mul r0, 4
-    add r0, window_list
-    mov [r0], 0
+    mov r2, r0
 
     ; set the active window to whatever entry is found first
     call search_for_nonempty_window_list_entry
@@ -206,8 +185,12 @@ destroy_window:
     cmp r0, 0xFFFFFFFF
     ifz jmp destroy_window_no_more_windows
 
-    ; set the menu bar for the newly active window
+    ; swap newly active window with the window about to be destroyed
     call window_list_offset_to_struct
+    mov r1, r2
+    call swap_windows
+
+    ; set the menu bar for the newly active window
     call get_window_menu_bar_root_struct
     call enable_menu_bar
     call clear_menu_bar
@@ -215,6 +198,29 @@ destroy_window:
     cmp r0, 0
     ifnz call draw_menu_bar_root_items
 destroy_window_no_more_windows:
+    ; free framebuffer memory
+    mov r0, [r2]
+    call free_memory
+
+    ; free event queue memory
+    add r2, 8
+    mov r0, [r2]
+    call free_memory
+
+    ; disable the window's overlay
+    add r2, 16
+    movz.8 r0, [r2]
+    call disable_overlay
+
+    ; remove the window from the window list
+    sub r2, 24
+    mov r0, r2
+    call search_for_window_list_entry
+    mul r0, 4
+    add r0, window_list
+    mov [r0], 0
+
+    pop r2
     pop r1
     pop r0
     ret


### PR DESCRIPTION
This PR modifies destroy_window so that it swaps the new active window with the previous active window that is about to be destroyed, ensuring that the new active window is on top. Fixes #20.