### PR TITLE
Add '%' debug prefix to shell

### DIFF
--- a/applications/sh/launch.asm
+++ b/applications/sh/launch.asm
@@ -15,13 +15,24 @@ launch_fxf:
     call copy_memory_bytes
     pop r0
 
+launch_fxf_check_suspend_prefix:
     ; if the name was prefixed with a '*' character then
     ; clear a flag to have the shell return control immediately
     cmp.8 [r0], '*'
     ifnz mov.8 [launch_fxf_yield_should_suspend], 1
-    ifnz jmp launch_fxf_no_prefix
+    ifnz jmp launch_fxf_check_debug_prefix
     inc r0
     mov.8 [launch_fxf_yield_should_suspend], 0
+    jmp launch_fxf_no_prefix
+launch_fxf_check_debug_prefix:
+    ; if the name was prefixed with a '%' character then
+    ; set a flag to cause a breakpoint at the beginning of the
+    ; program
+    cmp.8 [r0], '%'
+    ifnz mov.8 [launch_fxf_debug_mode], 0
+    ifnz jmp launch_fxf_no_prefix
+    inc r0
+    mov.8 [launch_fxf_debug_mode], 1
 launch_fxf_no_prefix:
     ; copy the name into the launch_fxf_name buffer
     mov r1, launch_fxf_name
@@ -66,6 +77,9 @@ launch_fxf_name_loop_done:
     ; push the argument pointers and terminal stream struct pointer to the task's stack
     call shell_parse_arguments
     mov r4, rsp
+    ; disable interrupts, because if an interrupt tried to use the stack
+    ; during this then that probably wouldn't end well
+    icl
     mov rsp, [launch_fxf_stack_ptr]
     add rsp, 65536 ; point to the end of the stack (stack grows down!!)
     push r3
@@ -73,13 +87,28 @@ launch_fxf_name_loop_done:
     push r1
     push r0
     push [shell_stream_struct_ptr]
-    sub rsp, 65516
-    mov [launch_fxf_stack_ptr], rsp
+    ; if we are in debug mode, push interrupt return info onto the stack
+    cmp.8 [launch_fxf_debug_mode], 0
+    ifz jmp launch_fxf_skip_push_reti_info
+    push 0 ; return address, will be filled in once we have start address
+    mov r1, rsp ; save address of return address to fill in later
+    push.8 0x04 ; enable interrupts upon return
+    push 0 ; don't care about exception parameter
+launch_fxf_skip_push_reti_info:
     mov rsp, r4
+    ise
 
     ; relocate the binary
     mov r0, [launch_fxf_binary_ptr]
     call parse_fxf_binary
+    ; if we are in debug mode, fill in the return adress with the relocation
+    ; address of the loaded binary
+    cmp.8 [launch_fxf_debug_mode], 0
+    ifz jmp launch_fxf_skip_fill_reti_addr
+    mov [r1], r0
+    ; set initial ip to launch_fxf_debug_start
+    mov r0, launch_fxf_debug_start
+launch_fxf_skip_fill_reti_addr:
 
     ; create a new task
     mov r1, r0
@@ -87,6 +116,9 @@ launch_fxf_name_loop_done:
     mov.8 [launch_fxf_task_id], r0
     mov r2, [launch_fxf_stack_ptr]
     add r2, 65516 ; point to the end of the stack (stack grows down!!)
+    ; if we are in debug mode, there are 9 extra bytes on top of the stack
+    cmp.8 [launch_fxf_debug_mode], 0
+    ifnz sub r2, 9
     mov r3, [launch_fxf_binary_ptr]
     mov r4, [launch_fxf_stack_ptr]
     call new_task
@@ -108,6 +140,12 @@ allocate_error:
     call print_str_to_terminal
     ret
 
+; entry point for a program started in debug mode
+launch_fxf_debug_start:
+    icl
+    ; jump indirect through system exception vector
+    jmp [0x00000410]
+
 launch_fxf_name: data.str "        fxf"
 launch_fxf_spaces: data.str "        "
 launch_fxf_struct: data.fill 0, 32
@@ -116,5 +154,6 @@ launch_fxf_binary_ptr: data.32 0
 launch_fxf_stack_ptr: data.32 0
 
 launch_fxf_yield_should_suspend: data.8 0
+launch_fxf_debug_mode: data.8 0
 
 out_of_memory_string: data.str "failed to allocate for new task!" data.8 10 data.8 0


### PR DESCRIPTION
This PR adds the '%' prefix, which could also be called the debug prefix, to the shell. It can be applied when loading an FXF executable similarly to the '*' prefix, which returns control to the shell immediately after a new task is started. The debug prefix causes the fox32 ROM monitor to be launched as soon as the program is loaded, but before execution begins. This will allow programmers to easily access the debugging capabilities of the ROM monitor when testing their applications.
Currently, the prefix checking code only tests the first character of the string, meaning that users cannot apply multiple prefixes at once.