### PR TITLE
`event_manager_task_loop` now exhausts event queue

### DIFF
--- a/applications/terminal/main.asm
+++ b/applications/terminal/main.asm
@@ -58,7 +58,7 @@ event_loop_end:
 mouse_down:
     ; check if we are attempting to drag or close the window
     cmp r2, 16
-    iflteq jmp drag_window
+    iflt jmp drag_window
 
     jmp event_loop_end
 
@@ -98,7 +98,7 @@ key_up:
 
 drag_window:
     cmp r1, 8
-    iflteq jmp event_loop_end
+    iflt jmp close_window
     mov r0, window_struct
     call start_dragging_window
     jmp event_loop_end

--- a/kernel/window/event_manager_task.asm
+++ b/kernel/window/event_manager_task.asm
@@ -51,6 +51,10 @@ event_manager_task_loop:
     ifz call add_event_to_active_window
     cmp r0, EVENT_TYPE_KEY_UP
     ifz call add_event_to_active_window
+
+    ; keep adding events until the queue is exhausted
+    cmp r0, EVENT_TYPE_EMPTY
+    ifnz jmp event_manager_task_loop
 event_manager_task_loop_end:
     call yield_task
     rjmp event_manager_task_loop


### PR DESCRIPTION
This solves the issue of "trailing" inputs when events of a given type are arriving faster than 60 FPS, such as a user holding down a key given a fast key repeat speed.