### PR TITLE
Run `startup.bat` from all disks

### DIFF
--- a/applications/sh/batch.asm
+++ b/applications/sh/batch.asm
@@ -8,9 +8,21 @@
 ; none (does not return)
 shell_run_batch:
     ; open the batch file
+    mov r0, [shell_batch_filename_ptr]
+    cmp.8 [r0], 0
+    ifz jmp shell_run_batch_failed_to_open
+    cmp.8 [r0 + 1], ':'
+    ifnz jmp fill_default_disk_id
+    movz.8 r1, [r0]
+    add r0, 2
+    sub r1, '0'
+    cmp r1, 4
+    iflt jmp open_batch_file
+fill_default_disk_id:
     call get_current_disk_id
     mov r1, r0
     mov r0, [shell_batch_filename_ptr]
+open_batch_file:
     mov r2, shell_batch_file_struct
     call open
     cmp r0, 0


### PR DESCRIPTION
Currently, fox32os on boot will execute `startup.bat` from the boot disk as a shell batch file. This commit extends this behavior to every disk that contains a `startup.bat`.